### PR TITLE
Rename all references to repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # markmonteiro.info
 
-[![Build Status](https://travis-ci.org/mark-monteiro/mark-monteiro.github.io.svg)](https://travis-ci.org/mark-monteiro/mark-monteiro.github.io)
-[![Code Climate](https://codeclimate.com/github/mark-monteiro/mark-monteiro.github.io/badges/gpa.svg)](https://codeclimate.com/github/mark-monteiro/mark-monteiro.github.io)
+[![Build Status](https://travis-ci.org/mark-monteiro/markmonteiro.info.svg)](https://travis-ci.org/mark-monteiro/markmonteiro.info)
+[![Code Climate](https://codeclimate.com/github/mark-monteiro/markmonteiro.info/badges/gpa.svg)](https://codeclimate.com/github/mark-monteiro/markmonteiro.info)
 
 My personal website. Built with Jekyll, a static website generation framework, and hosted on Netlify.
 

--- a/_projects/markmonteiroinfo.html
+++ b/_projects/markmonteiroinfo.html
@@ -2,7 +2,7 @@
 title: Mark Monteiro
 order: 2
 website: http://markmonteiro.info
-source: https://github.com/mark-monteiro/mark-monteiro.github.io
+source: https://github.com/mark-monteiro/markmonteiro.info
 developed: April 2015
 technologies:
   - Jekyll

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mark-monteiro.github.io",
+  "name": "markmonteiro.info",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mark-monteiro.github.io",
+  "name": "markmonteiro.info",
   "version": "1.0.0",
   "description": "Mark Monteiro's personal website",
   "scripts": {
@@ -7,14 +7,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mark-monteiro/mark-monteiro.github.io.git"
+    "url": "git+https://github.com/mark-monteiro/markmonteiro.info.git"
   },
   "author": "Mark Monteiro",
   "license": "SEE LICENSE IN LICENSE.",
   "bugs": {
-    "url": "https://github.com/mark-monteiro/mark-monteiro.github.io/issues"
+    "url": "https://github.com/mark-monteiro/markmonteiro.info/issues"
   },
-  "homepage": "https://github.com/mark-monteiro/mark-monteiro.github.io#readme",
+  "homepage": "https://github.com/mark-monteiro/markmonteiro.info#readme",
   "devDependencies": {
     "bootstrap-sass": "^3.4.1",
     "stylelint": "^11.0.0",


### PR DESCRIPTION
We are no longer using Github Pages so we need to rename the repository to turn off that integration